### PR TITLE
Add timer mechanism to check QRCode validity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,15 +20,14 @@
         <activity
             android:name=".StartActivity"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar"
-            android:windowSoftInputMode="adjustPan" >
-        </activity>
+            android:windowSoftInputMode="adjustPan" />
         <activity
             android:name=".MainActivity"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar"
-            android:windowSoftInputMode="adjustPan" >
+            android:windowSoftInputMode="adjustPan">
+
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>

--- a/app/src/main/java/com/nckumbi/cityrun/GameMenuActivity.java
+++ b/app/src/main/java/com/nckumbi/cityrun/GameMenuActivity.java
@@ -99,10 +99,10 @@ public class GameMenuActivity extends AppCompatActivity {
             }
         });
 
-        initializeComponents();
-
         gameMenuQrCodeImageButton.setOnClickListener(qrCodeImageButtonClicked);
         gameMenuEnterGameImageButton.setOnClickListener(enterGameImageButtonOnClicked);
+
+        initializeComponents();
     }
 
     @Override
@@ -148,6 +148,13 @@ public class GameMenuActivity extends AppCompatActivity {
             if (resultCode == GameHelper.QRCODE_VALID_RESULT_CODE) {
                 unlockLevel(data.getStringExtra("serial"));
             }
+        } else if (requestCode == GameHelper.ACTIVITY_REQUEST_CODE) {
+            if (resultCode == GameHelper.QRCODE_EXPIRED_RESULT_CODE) {
+                initializeComponents(false);
+                Utils.showDialog(GameMenuActivity.this, "無效的 QRCode",
+                        "此 QRCode 自掃描後已超過三小時，無法再度使用！");
+                GameHelper.saveCurrentSerial(GameMenuActivity.this, null);
+            }
         }
     }
 
@@ -161,23 +168,36 @@ public class GameMenuActivity extends AppCompatActivity {
         }
     };
 
-    protected  View.OnClickListener enterGameImageButtonOnClicked = new View.OnClickListener() {
+    protected View.OnClickListener enterGameImageButtonOnClicked = new View.OnClickListener() {
         @Override
         public void onClick(View v) {
             Intent intent = new Intent();
             intent.setClass(GameMenuActivity.this, ChapterSelectActivity.class);
-            startActivity(intent);
+            startActivityForResult(intent, GameHelper.ACTIVITY_REQUEST_CODE);
             overridePendingTransition(R.anim.fade_in, R.anim.fade_out);
         }
     };
 
     protected void initializeComponents() {
-        if (!isUnlocked()) {
+        initializeComponents(isUnlocked());
+    }
+
+    protected void initializeComponents(boolean unlocked) {
+        if (!unlocked) {
             gameMenuMask.setVisibility(View.VISIBLE);
             gameMenuChainRight.setVisibility(View.VISIBLE);
             gameMenuChainLeft.setVisibility(View.VISIBLE);
             gameMenuQrCodeImageButton.setVisibility(View.VISIBLE);
             gameMenuLockImageButton.setVisibility(View.VISIBLE);
+
+            gameMenuChainLeft.setX(0);
+            gameMenuChainLeft.setY(
+                    (getWindow().getDecorView().getHeight() - gameMenuChainLeft.getHeight()) / 2);
+
+            gameMenuChainRight.setX(0);
+            gameMenuChainRight.setY(
+                    (getWindow().getDecorView().getHeight() - gameMenuChainRight.getHeight()) / 2);
+
             gameMenuMask.setAlpha(1.0f);
             gameMenuChainRight.setAlpha(1.0f);
             gameMenuChainLeft.setAlpha(1.0f);
@@ -203,6 +223,7 @@ public class GameMenuActivity extends AppCompatActivity {
                 GameHelper.getStartTime(GameMenuActivity.this, currentSerial)) >= GameHelper.AVAILABLE_DURATION) {
             Utils.showDialog(GameMenuActivity.this, "無效的 QRCode",
                     "此 QRCode 自掃描後已超過三小時，無法再度使用！");
+            GameHelper.saveCurrentSerial(GameMenuActivity.this, null);
             return false;
         }
 

--- a/app/src/main/java/com/nckumbi/cityrun/QrCodeActivity.java
+++ b/app/src/main/java/com/nckumbi/cityrun/QrCodeActivity.java
@@ -128,6 +128,12 @@ public class QrCodeActivity extends AppCompatActivity implements ZBarScannerView
         final Long startTime = GameHelper.getStartTime(QrCodeActivity.this, data);
 
         if (GameHelper.getElapsedTime(startTime) < GameHelper.AVAILABLE_DURATION) {
+            // FIXME: The following is demo code.
+            if (data.length() < 9 || !data.substring(0, 9).equals("startgame")) {
+                scannerView.resumeCameraPreview(this);
+                return;
+            }
+
             Intent intent = new Intent();
             intent.putExtra("serial", data);
 

--- a/app/src/main/java/com/nckumbi/cityrun/utils/GameHelper.java
+++ b/app/src/main/java/com/nckumbi/cityrun/utils/GameHelper.java
@@ -2,18 +2,24 @@ package com.nckumbi.cityrun.utils;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.support.v7.app.AppCompatActivity;
+import android.util.Base64;
+import android.widget.TextView;
 
 import com.nckumbi.cityrun.R;
+
+import java.util.TimerTask;
 
 /**
  * Created by user on 2016/5/22.
  */
 public class GameHelper {
+    public static final int ACTIVITY_REQUEST_CODE = 0x000;
     public static final int QRCODE_SCANNER_REQUEST_CODE = 0x0001;
     public static final int QRCODE_EXPIRED_RESULT_CODE = 0x0002;
     public static final int QRCODE_VALID_RESULT_CODE = 0x0003;
 
-    public static final Long AVAILABLE_DURATION = 3600 * 3L;
+    public static final long AVAILABLE_DURATION = 3600 * 3L;
 
     public static final String PREF_CURRENT_SERIAL = "serial";
 
@@ -21,35 +27,80 @@ public class GameHelper {
         SharedPreferences preferences = context.getSharedPreferences(
                 context.getResources().getString(R.string.app_name), Context.MODE_PRIVATE);
 
-        preferences.edit().putString(PREF_CURRENT_SERIAL, serial).apply();
+        if (serial == null || serial.isEmpty()) {
+            preferences.edit().remove(PREF_CURRENT_SERIAL).apply();
+        } else {
+            preferences.edit().putString(PREF_CURRENT_SERIAL,
+                    Base64.encodeToString(serial.getBytes(), Base64.NO_WRAP)).apply();
+        }
     }
 
     public static String getCurrentSerial(Context context) {
         SharedPreferences preferences = context.getSharedPreferences(
                 context.getResources().getString(R.string.app_name), Context.MODE_PRIVATE);
 
-        return preferences.getString(PREF_CURRENT_SERIAL, null);
+        String result = preferences.getString(PREF_CURRENT_SERIAL, null);
+        if (result != null) {
+            result = new String(Base64.decode(result, Base64.NO_WRAP));
+        }
+
+        return result;
     }
 
     public static void saveStartTime(Context context, String serial) {
         SharedPreferences preferences = context.getSharedPreferences(
                 context.getResources().getString(R.string.app_name), Context.MODE_PRIVATE);
 
-        if (!preferences.contains(serial)) {
-            preferences.edit().putLong(serial, System.currentTimeMillis() / 1000L).apply();
+        String base64Serial = Base64.encodeToString(serial.getBytes(), Base64.NO_WRAP);
+        if (!preferences.contains(base64Serial)) {
+            preferences.edit().putLong(base64Serial, getNowTimestamp()).apply();
         }
     }
 
-    public static Long getStartTime(Context context, String serial) {
+    public static long getStartTime(Context context, String serial) {
         SharedPreferences preferences = context.getSharedPreferences(
                 context.getResources().getString(R.string.app_name), Context.MODE_PRIVATE);
 
-        return preferences.getLong(serial, System.currentTimeMillis() / 1000L);
+        return preferences.getLong(
+                Base64.encodeToString(serial.getBytes(), Base64.NO_WRAP), getNowTimestamp());
     }
 
-    public static Long getElapsedTime(Long startTime) {
-        Long currentTime = System.currentTimeMillis() / 1000L;
+    public static long getElapsedTime(Long startTime) {
+        return getNowTimestamp() - startTime;
+    }
 
-        return currentTime - startTime;
+    public static long getNowTimestamp() {
+        return System.currentTimeMillis() / 1000L;
+    }
+
+    public static class ExpiredCheckTask extends TimerTask {
+        private AppCompatActivity activity;
+        private TextView clockTextView;
+        private long elapsedTime;
+
+        public ExpiredCheckTask(AppCompatActivity activity, TextView clockTextView, long startTime) {
+            this.activity = activity;
+            this.clockTextView = clockTextView;
+            this.elapsedTime = GameHelper.getElapsedTime(startTime);
+        }
+
+        @Override
+        public void run() {
+            ++elapsedTime;
+
+            activity.runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    clockTextView.setText(
+                            String.format("%02d:%02d:%02d",
+                                    elapsedTime / 3600, (elapsedTime % 3600) / 60, elapsedTime % 60));
+
+                    if (elapsedTime >= GameHelper.AVAILABLE_DURATION) {
+                        activity.setResult(GameHelper.QRCODE_EXPIRED_RESULT_CODE);
+                        activity.finish();
+                    }
+                }
+            });
+        }
     }
 }

--- a/barcodescanner.core/barcodescanner.core.iml
+++ b/barcodescanner.core/barcodescanner.core.iml
@@ -65,14 +65,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
@@ -81,6 +73,14 @@
       <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/annotations" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
@@ -103,6 +103,5 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" exported="" name="support-v4-23.1.1" level="project" />
     <orderEntry type="library" exported="" name="support-annotations-23.1.1" level="project" />
-    <orderEntry type="library" exported="" name="android-android-23" level="project" />
   </component>
 </module>

--- a/barcodescanner.zbar/barcodescanner.zbar.iml
+++ b/barcodescanner.zbar/barcodescanner.zbar.iml
@@ -65,14 +65,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
@@ -81,6 +73,14 @@
       <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/annotations" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
@@ -104,6 +104,5 @@
     <orderEntry type="library" exported="" name="zbar" level="project" />
     <orderEntry type="library" exported="" name="support-annotations-23.1.1" level="project" />
     <orderEntry type="module" module-name="barcodescanner.core" exported="" />
-    <orderEntry type="library" exported="" name="android-android-23" level="project" />
   </component>
 </module>


### PR DESCRIPTION
In each activity, there is a timer to check QRCode validity per second.

Current activity will use `setResult(GameHelper.QRCODE_EXPIRED_RESULT_CODE)` to 
inform previous one when QRCode is expired.

So you must override `onActivityResult` method and
use `startActivityForResult(intent, GameHelper.ACTIVITY_REQUEST_CODE)` to start new activity.

The following is sample code:
In Caller,

``` java
void startNextActivity() {
    Intent intent = new Intent();

    intent.setClass(CurrentActivity.this, NextActivity.class);
    startActivityForResult(intent, GameHelper.ACTIVITY_REQUEST_CODE);
}

@Override
protected void onActivityResult(int requestCode, int resultCode, Intent data) {
    if (requestCode == GameHelper.ACTIVITY_REQUEST_CODE) {
        if (resultCode == GameHelper.QRCODE_EXPIRED_RESULT_CODE) {
            setResult(resultCode);
            CurrentActivity.this.finish();
        }
    }
}
```

In Callee,

``` java
@Override
protected void onResume() {
    super.onResume();

    if (expiredCheckTimer == null) {
        expiredCheckTimer = new Timer(true);
        expiredCheckTimer.schedule(new GameHelper.ExpiredCheckTask(
                CurrentActivity.this,
                ClockTextView,
                GameHelper.getStartTime(CurrentActivity.this, currentSerial)
        ), 0, 1000);
    }
}

@Override
protected void onPause() {
    super.onPause();

    if (expiredCheckTimer != null) {
        expiredCheckTimer.cancel();
        expiredCheckTimer = null;
    }
}
```
